### PR TITLE
Fix repo cloning error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A PyTorch implementation of DTrOCR: Decoder-only Transformer for Optical Charact
 ## Installation
 
 ```shell
-git clone git@github.com:arvindrajan92/DTrOCR.git
+git clone https://github.com/arvindrajan92/DTrOCR
 cd DTrOCR
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
Removed minor issue that appeared due to credentials while cloning.

![Screenshot 2024-07-27 224639](https://github.com/user-attachments/assets/7e6b97b0-fe2f-4f3c-bd70-1e8daa3ba388)
